### PR TITLE
Parsing Lunch Time as datetime

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -1,6 +1,7 @@
 import zulip
 
 from lib.models.message import Message
+from lib.models.plan import Plan
 
 
 def send_reply(client: zulip.Client, message: Message, reply: str):
@@ -20,3 +21,10 @@ def send_reply(client: zulip.Client, message: Message, reply: str):
             "content": reply,
         }
     )
+
+
+def render_plan_time(plan: Plan) -> str:
+    """
+    Renders the time of a plan as we would want it to appear to the user.
+    """
+    return plan.time.strftime("%I:%M%p").lower()

--- a/lib/handlers/make_plan.py
+++ b/lib/handlers/make_plan.py
@@ -1,3 +1,5 @@
+import regex as re
+from datetime import datetime
 from typing import List
 import zulip
 
@@ -19,10 +21,20 @@ def handle_make_plan(
         )
         return
 
-    # TODO (#2): Do validation on date, so that we can infer the time from the
-    #            date input.
+    try:
+        plan_time = parse_time(args[2])
+    except ValueError as e:
+        common.send_reply(
+            client,
+            message,
+            "Sorry, the time you entered could not be used because: it is {}.".format(
+                e
+            ),
+        )
+        return
+
     user = User.get_sender(message)
-    plan = Plan(args[1], args[2], [user])
+    plan = Plan(args[1], plan_time, [user])
 
     if not storage.contains(storage.PLANS_ENTRY):
         storage.put(storage.PLANS_ENTRY, [])
@@ -36,3 +48,46 @@ def handle_make_plan(
         message,
         "I have added your plan! Enjoy lunch, {}!".format(user.full_name),
     )
+
+
+def parse_time(date_str: str) -> datetime:
+    """
+    Parses out a string-formatted date into a well-structured datetime in UTC.
+    Supports any of the following formats:
+
+      - hh:mm
+
+        In this format, we treat the value of the hh section to be 24hr format.
+        If a user types in 1:00, it will be interpreted as 1am, not 1pm.
+
+      - hh:mm(am|pm)
+
+        In this format, we treat the value of the hh section to be 12hr format,
+        and we rely on the am/pm flag to determine whether it is in the morning
+        or the afternoon.
+    """
+    match = re.match(r"(\d?\d):(\d\d)(am|pm)?", date_str)
+    if match is None:
+        raise ValueError("not an interpretable date format")
+
+    groups = match.groups()
+    hour = int(groups[0])
+    minute = int(groups[1])
+    if groups[2] == "pm" and hour < 12:
+        hour += 12
+
+    now = datetime.now()
+    time = datetime(
+        year=now.year,
+        month=now.month,
+        day=now.day,
+        hour=hour,
+        minute=minute,
+        second=0,
+        microsecond=0,
+    )
+
+    if time < now:
+        raise ValueError("before current time")
+
+    return time

--- a/lib/handlers/my_plans.py
+++ b/lib/handlers/my_plans.py
@@ -8,7 +8,7 @@ from lib.state_handler import StateHandler
 
 
 def handle_my_plans(
-    client: zulip.Client, storage: StateHandler, message: Message, args: List[str],
+    client: zulip.Client, storage: StateHandler, message: Message, args: List[str]
 ):
     if (
         not storage.contains(storage.PLANS_ENTRY)
@@ -17,7 +17,7 @@ def handle_my_plans(
         common.send_reply(
             client,
             message,
-            "There are no active lunch plans right now! Why not add one using the make-plan command?"
+            "There are no active lunch plans right now! Why not add one using the make-plan command?",
         )
         return
 
@@ -29,7 +29,10 @@ def handle_my_plans(
             "\n".join(
                 [
                     "{}: {} @ {}, {} RSVP(s)".format(
-                        i, plan.restaurant, plan.time, len(plan.rsvps),
+                        i,
+                        plan.restaurant,
+                        common.render_plan_time(plan),
+                        len(plan.rsvps),
                     )
                     for i, plan in enumerate(storage.get(storage.PLANS_ENTRY))
                     if user in plan.rsvps

--- a/lib/handlers/show_plans.py
+++ b/lib/handlers/show_plans.py
@@ -7,7 +7,7 @@ from lib.state_handler import StateHandler
 
 
 def handle_show_plans(
-    client: zulip.Client, storage: StateHandler, message: Message, args: List[str],
+    client: zulip.Client, storage: StateHandler, message: Message, args: List[str]
 ):
     if (
         not storage.contains(storage.PLANS_ENTRY)
@@ -26,7 +26,7 @@ def handle_show_plans(
         "\n".join(
             [
                 "{}: {} @ {}, {} RSVP(s)".format(
-                    i, plan.restaurant, plan.time, len(plan.rsvps),
+                    i, plan.restaurant, common.render_plan_time(plan), len(plan.rsvps)
                 )
                 for i, plan in enumerate(storage.get(storage.PLANS_ENTRY))
             ]

--- a/lib/models/plan.py
+++ b/lib/models/plan.py
@@ -1,10 +1,11 @@
+from datetime import datetime
 from typing import List
 
 from lib.models.user import User
 
 
 class Plan:
-    def __init__(self, restaurant: str, time: str, rsvps: List[User]):
+    def __init__(self, restaurant: str, time: datetime, rsvps: List[User]):
         self.restaurant = restaurant
         self.time = time
         self.rsvps = rsvps

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import time
 from typing import List
 from typing import Tuple
@@ -65,3 +66,20 @@ def make_zulip_message():
         return message, args
 
     return _make_zulip_message
+
+
+@pytest.fixture
+def make_time():
+    def _make_time(hour: int, minute: int) -> datetime:
+        now = datetime.now()
+        return datetime(
+            year=now.year,
+            month=now.month,
+            day=now.day,
+            hour=hour,
+            minute=minute,
+            second=0,
+            microsecond=0,
+        )
+
+    return _make_time

--- a/tests/lib/handlers/test_delete_plan.py
+++ b/tests/lib/handlers/test_delete_plan.py
@@ -14,9 +14,7 @@ def test_handle_delete_plan_bad_args(
     response.
     """
     message, args = make_zulip_message("delete-plan")
-    handle_delete_plan(
-        mock_client, mock_storage, message, args,
-    )
+    handle_delete_plan(mock_client, mock_storage, message, args)
 
     mock_send_reply.assert_called_with(
         mock_client,
@@ -26,16 +24,14 @@ def test_handle_delete_plan_bad_args(
 
 
 def test_handle_delete_plan_no_plans(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message,
+    mock_client, mock_storage, mock_send_reply, make_zulip_message
 ):
     """
     Ensures that handle_delete_plan functions correctly when the StateHandler
     has no plans available to use.
     """
     message, args = make_zulip_message("delete-plan 0")
-    handle_delete_plan(
-        mock_client, mock_storage, message, args,
-    )
+    handle_delete_plan(mock_client, mock_storage, message, args)
 
     mock_send_reply.assert_called_with(
         mock_client,
@@ -45,20 +41,16 @@ def test_handle_delete_plan_no_plans(
 
 
 def test_handle_delete_plan_malformed_id(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures that handle_delete_plan functions correctly when the user provides
     a non-integer ID.
     """
-    mock_storage.get.return_value = [
-        Plan("tjs", "12:30", []),
-    ]
+    mock_storage.get.return_value = [Plan("tjs", make_time(12, 30), [])]
 
     message, args = make_zulip_message("delete-plan not-a-lunch")
-    handle_delete_plan(
-        mock_client, mock_storage, message, args,
-    )
+    handle_delete_plan(mock_client, mock_storage, message, args)
 
     mock_send_reply.assert_called_with(
         mock_client,
@@ -68,20 +60,16 @@ def test_handle_delete_plan_malformed_id(
 
 
 def test_handle_delete_plan_bad_id(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures that handle_delete_plan functions correctly when the user provides
     an integer ID that does not correspond to a plan.
     """
-    mock_storage.get.return_value = [
-        Plan("tjs", "12:30", []),
-    ]
+    mock_storage.get.return_value = [Plan("tjs", make_time(12, 30), [])]
 
     message, args = make_zulip_message("delete-plan 1")
-    handle_delete_plan(
-        mock_client, mock_storage, message, args,
-    )
+    handle_delete_plan(mock_client, mock_storage, message, args)
 
     mock_send_reply.assert_called_with(
         mock_client,
@@ -91,16 +79,12 @@ def test_handle_delete_plan_bad_id(
 
 
 def test_handle_delete_plan_success(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
-    mock_storage.get.return_value = [
-        Plan("tjs", "12:30", []),
-    ]
+    mock_storage.get.return_value = [Plan("tjs", make_time(12, 30), [])]
 
     message, args = make_zulip_message("delete-plan 0")
-    handle_delete_plan(
-        mock_client, mock_storage, message, args,
-    )
+    handle_delete_plan(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_called_with(mock_storage.PLANS_ENTRY, [])
     mock_send_reply.assert_called_with(

--- a/tests/lib/handlers/test_make_plan.py
+++ b/tests/lib/handlers/test_make_plan.py
@@ -12,9 +12,7 @@ def test_handle_make_plan_bad_args(
     message.
     """
     message, args = make_zulip_message("make-plan tjs 12:30 and-another-arg")
-    handle_make_plan(
-        mock_client, mock_storage, message, args,
-    )
+    handle_make_plan(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_not_called()
     mock_send_reply.assert_called_with(
@@ -25,7 +23,7 @@ def test_handle_make_plan_bad_args(
 
 
 def test_handle_make_plan_success(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures that make_plan correctly inserts a plan when the arguments are
@@ -34,10 +32,9 @@ def test_handle_make_plan_success(
     mock_storage.get.return_value = []
 
     message, args = make_zulip_message("make-plans tjs 12:30")
-    handle_make_plan(
-        mock_client, mock_storage, message, args,
-    )
+    handle_make_plan(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_called_with(
-        mock_storage.PLANS_ENTRY, [Plan("tjs", "12:30", [User("Test Sender", 5678)]),]
+        mock_storage.PLANS_ENTRY,
+        [Plan("tjs", make_time(12, 30), [User("Test Sender", 5678)])],
     )

--- a/tests/lib/handlers/test_my_plans.py
+++ b/tests/lib/handlers/test_my_plans.py
@@ -36,5 +36,5 @@ def test_handle_my_plans_success(
     mock_send_reply.assert_called_with(
         mock_client,
         message,
-        "Here are the lunches you've RSVP'd to:\n0: tjs @ 12:30, 1 RSVP(s)",
+        "Here are the lunches you've RSVP'd to:\n0: tjs @ 12:30pm, 1 RSVP(s)",
     )

--- a/tests/lib/handlers/test_my_plans.py
+++ b/tests/lib/handlers/test_my_plans.py
@@ -11,9 +11,7 @@ def test_handle_my_plans_no_plans(
     shown.
     """
     message, args = make_zulip_message("my-plans")
-    handle_my_plans(
-        mock_client, mock_storage, message, args,
-    )
+    handle_my_plans(mock_client, mock_storage, message, args)
 
     mock_send_reply.assert_called_with(
         mock_client,
@@ -23,17 +21,17 @@ def test_handle_my_plans_no_plans(
 
 
 def test_handle_my_plans_success(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message,
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Checks that, when the user has a plan, the correct list is shown.
     """
-    mock_storage.get.return_value = [Plan("tjs", "12:30", [User("Test Sender", 5678)])]
+    mock_storage.get.return_value = [
+        Plan("tjs", make_time(12, 30), [User("Test Sender", 5678)])
+    ]
 
     message, args = make_zulip_message("my-plans")
-    handle_my_plans(
-        mock_client, mock_storage, message, args,
-    )
+    handle_my_plans(mock_client, mock_storage, message, args)
 
     mock_send_reply.assert_called_with(
         mock_client,

--- a/tests/lib/handlers/test_rsvp.py
+++ b/tests/lib/handlers/test_rsvp.py
@@ -11,9 +11,7 @@ def test_handle_rsvp_bad_args(
     incorrect number of arguments.
     """
     message, args = make_zulip_message("rsvp tjs also-this-extra-arg")
-    handle_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_not_called()
     mock_send_reply.assert_called_with(
@@ -30,9 +28,7 @@ def test_handle_rsvp_no_plans(
     Ensures that handle_rsvp fails as expected when there are no plans.
     """
     message, args = make_zulip_message("rsvp 0")
-    handle_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_not_called()
     mock_send_reply.assert_called_with(
@@ -43,18 +39,16 @@ def test_handle_rsvp_no_plans(
 
 
 def test_handle_rsvp_malformed_id(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures that handle_rsvp failes correctly when the plan ID is malformed
     (i.e. it cannot be coerced to int).
     """
-    mock_storage.get.return_value = [Plan("tjs", "12:30", [])]
+    mock_storage.get.return_value = [Plan("tjs", make_time(12, 30), [])]
 
     message, args = make_zulip_message("rsvp not-an-id")
-    handle_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_not_called()
     mock_send_reply.assert_called_with(
@@ -65,18 +59,16 @@ def test_handle_rsvp_malformed_id(
 
 
 def test_handle_rsvp_bad_id(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures that handle_rsvp failes correctly when the plan ID is not malformed
     but does not correspond to a plan.
     """
-    mock_storage.get.return_value = [Plan("tjs", "12:30", [])]
+    mock_storage.get.return_value = [Plan("tjs", make_time(12, 30), [])]
 
     message, args = make_zulip_message("rsvp 1")
-    handle_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_not_called()
     mock_send_reply.assert_called_with(
@@ -87,18 +79,18 @@ def test_handle_rsvp_bad_id(
 
 
 def test_handle_rsvp_already_rsvpd(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures handle_rsvp fails correctly when the user is already RSVP'd to the
     event to which they're trying to rsvp.
     """
-    mock_storage.get.return_value = [Plan("tjs", "12:30", [User("Test Sender", 5678)])]
+    mock_storage.get.return_value = [
+        Plan("tjs", make_time(12, 30), [User("Test Sender", 5678)])
+    ]
 
     message, args = make_zulip_message("rsvp 0")
-    handle_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_not_called()
     mock_send_reply.assert_called_with(
@@ -109,21 +101,20 @@ def test_handle_rsvp_already_rsvpd(
 
 
 def test_handle_rsvp_success(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures that handle_rsvp functions correctly when the preconditions are
     met.
     """
-    mock_storage.get.return_value = [Plan("tjs", "12:30", [])]
+    mock_storage.get.return_value = [Plan("tjs", make_time(12, 30), [])]
 
     message, args = make_zulip_message("rsvp 0")
-    handle_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_called_with(
-        mock_storage.PLANS_ENTRY, [Plan("tjs", "12:30", [User("Test Sender", 5678)])]
+        mock_storage.PLANS_ENTRY,
+        [Plan("tjs", make_time(12, 30), [User("Test Sender", 5678)])],
     )
     mock_send_reply.assert_called_with(
         mock_client,

--- a/tests/lib/handlers/test_show_plans.py
+++ b/tests/lib/handlers/test_show_plans.py
@@ -10,9 +10,7 @@ def test_handle_show_plans_no_plans(
     user.
     """
     message, args = make_zulip_message("show-plans")
-    handle_show_plans(
-        mock_client, mock_storage, message, args,
-    )
+    handle_show_plans(mock_client, mock_storage, message, args)
 
     mock_send_reply.assert_called_with(
         mock_client,
@@ -22,21 +20,17 @@ def test_handle_show_plans_no_plans(
 
 
 def test_handle_show_plans_success(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time,
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures that, if there are plans, handle_show_plans shows the user all of
     the plans.
     """
-    mock_storage.get.return_value = [
-        Plan("tjs", make_time(12, 30), []),
-    ]
+    mock_storage.get.return_value = [Plan("tjs", make_time(12, 30), [])]
 
     message, args = make_zulip_message("show-plans")
-    handle_show_plans(
-        mock_client, mock_storage, message, args,
-    )
+    handle_show_plans(mock_client, mock_storage, message, args)
 
     mock_send_reply.assert_called_with(
-        mock_client, message, "0: tjs @ 12:30, 0 RSVP(s)",
+        mock_client, message, "0: tjs @ 12:30pm, 0 RSVP(s)"
     )

--- a/tests/lib/handlers/test_show_plans.py
+++ b/tests/lib/handlers/test_show_plans.py
@@ -22,14 +22,14 @@ def test_handle_show_plans_no_plans(
 
 
 def test_handle_show_plans_success(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time,
 ):
     """
     Ensures that, if there are plans, handle_show_plans shows the user all of
     the plans.
     """
     mock_storage.get.return_value = [
-        Plan("tjs", "12:30", []),
+        Plan("tjs", make_time(12, 30), []),
     ]
 
     message, args = make_zulip_message("show-plans")

--- a/tests/lib/handlers/test_un_rsvp.py
+++ b/tests/lib/handlers/test_un_rsvp.py
@@ -11,9 +11,7 @@ def test_handle_un_rsvp_bad_args(
     arguments.
     """
     message, args = make_zulip_message("un-rsvp 0 5")
-    handle_un_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_un_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_not_called()
     mock_send_reply.assert_called_with(
@@ -31,9 +29,7 @@ def test_handle_un_rsvp_no_lunches(
     un-rsvp from.
     """
     message, args = make_zulip_message("un-rsvp 0")
-    handle_un_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_un_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_not_called()
     mock_send_reply.assert_called_with(
@@ -44,18 +40,18 @@ def test_handle_un_rsvp_no_lunches(
 
 
 def test_handle_un_rsvp_malformed_id(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures that handle_un_rsvp fails as expected when the user provides an id
     that is not a number.
     """
-    mock_storage.get.return_value = [Plan("tjs", "12:30", [User("Test Sender", 5678)])]
+    mock_storage.get.return_value = [
+        Plan("tjs", make_time(12, 30), [User("Test Sender", 5678)])
+    ]
 
     message, args = make_zulip_message("un-rsvp text")
-    handle_un_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_un_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_not_called()
     mock_send_reply.assert_called_with(
@@ -66,18 +62,18 @@ def test_handle_un_rsvp_malformed_id(
 
 
 def test_handle_un_rsvp_bad_id(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures that handle_un_rsvp fails as expected when the user provides an id
     that is out of range of our available lunches.
     """
-    mock_storage.get.return_value = [Plan("tjs", "12:30", [User("Test Sender", 5678)])]
+    mock_storage.get.return_value = [
+        Plan("tjs", make_time(12, 30), [User("Test Sender", 5678)])
+    ]
 
     message, args = make_zulip_message("un-rsvp 1")
-    handle_un_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_un_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_not_called()
     mock_send_reply.assert_called_with(
@@ -88,44 +84,40 @@ def test_handle_un_rsvp_bad_id(
 
 
 def test_handle_un_rsvp_not_rsvpd(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message,
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures that handle_un_rsvp fails as expected when the user is not already
     RSVP'd to the event.
     """
-    mock_storage.get.return_value = [Plan("tjs", "12:30", [])]
+    mock_storage.get.return_value = [Plan("tjs", make_time(12, 30), [])]
 
     message, args = make_zulip_message("un-rsvp 0")
-    handle_un_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_un_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put.assert_not_called()
     mock_send_reply.assert_called_with(
-        mock_client,
-        message,
-        "Oops! It looks like you haven't RSVP'd to this lunch_id!",
+        mock_client, message, "Oops! It looks like you haven't RSVP'd to this lunch_id!"
     )
 
 
 def test_handle_un_rsvp_success(
-    mock_client, mock_storage, mock_send_reply, make_zulip_message
+    mock_client, mock_storage, mock_send_reply, make_zulip_message, make_time
 ):
     """
     Ensures that handle_un_rsvp succeeds when the required preconditions are
     met.
     """
-    mock_storage.get.return_value = [Plan("tjs", "12:30", [User("Test Sender", 5678)])]
+    mock_storage.get.return_value = [
+        Plan("tjs", make_time(12, 30), [User("Test Sender", 5678)])
+    ]
 
     message, args = make_zulip_message("un-rsvp 0")
-    handle_un_rsvp(
-        mock_client, mock_storage, message, args,
-    )
+    handle_un_rsvp(mock_client, mock_storage, message, args)
 
     mock_storage.put_assert_called_with(
-        mock_storage.PLANS_ENTRY, Plan("tjs", "12:30", [])
+        mock_storage.PLANS_ENTRY, Plan("tjs", make_time(12, 30), [])
     )
     mock_send_reply.assert_called_with(
-        mock_client, message, "You've successful un-RSVP'd to lunch at tjs.",
+        mock_client, message, "You've successful un-RSVP'd to lunch at tjs."
     )


### PR DESCRIPTION
Moving from `Plan.time : str` to `Plan.time : datetime`. Addresses #2.